### PR TITLE
Clean up Nav Bar

### DIFF
--- a/frontend/src/components/NavBar/NavBar.js
+++ b/frontend/src/components/NavBar/NavBar.js
@@ -34,23 +34,8 @@ function NavBar() {
                 navbarScroll
               >
                 <Nav.Link href={"/transactions"}>All Transactions</Nav.Link>
-                <NavDropdown title="Menu" id="navbarScrollingDropdown">
-                  <NavDropdown.Item href={"/profile"}>Profile</NavDropdown.Item>
-                  <NavDropdown.Divider />
-                  <NavDropdown.Item onClick={logoutUser}>
-                    Logout
-                  </NavDropdown.Item>
-                </NavDropdown>
+                <Nav.Link onClick={logoutUser}>Logout</Nav.Link>
               </Nav>
-              <Form className="d-flex">
-                <Form.Control
-                  type="search"
-                  placeholder="Search Transaction"
-                  className="me-2"
-                  aria-label="Search"
-                />
-                <Button variant="primary">Search</Button>
-              </Form>
             </Navbar.Collapse>
           </Container>
         </Navbar>

--- a/frontend/src/components/TransactionTable/TransactionRow.js
+++ b/frontend/src/components/TransactionTable/TransactionRow.js
@@ -24,7 +24,7 @@ function TransactionRow({ transaction }) {
       <td>{transaction.description}</td>
       <td>{transaction.type}</td>
       <td>{transaction.category}</td>
-      <td>{transaction.amount}</td>
+      <td>${transaction.amount}</td>
       <td className="d-flex gap-2">
         <EditTransaction transaction={transaction} />
         <Button variant="outline-danger" onClick={handleDelete}>


### PR DESCRIPTION
## Clean up Nav Bar
- Remove profile option
- Move logout option to same level as "all transactions"
- Removed menu dropdown
- Removed search bar

# Full screen view:
<img width="1165" alt="Screenshot 2023-03-28 at 1 10 29 PM" src="https://user-images.githubusercontent.com/115976648/228343081-96f6b441-ba34-4bf2-8a66-038ba6953d3c.png">

# Collapsed menu view:
<img width="887" alt="Screenshot 2023-03-28 at 1 12 28 PM" src="https://user-images.githubusercontent.com/115976648/228343238-5517e707-f39b-45f0-b722-3dbbe2b333c7.png">


## Add $ to transaction row amounts
<img width="702" alt="Screenshot 2023-03-28 at 1 14 14 PM" src="https://user-images.githubusercontent.com/115976648/228343568-78ef3d9f-a161-4e62-afe4-6267325792a0.png">
